### PR TITLE
feat: install dependencies with custom cert behind https proxy

### DIFF
--- a/installer.py
+++ b/installer.py
@@ -1,0 +1,51 @@
+import os
+import logging
+import subprocess
+import sys
+
+logger = logging.getLogger()
+handler = logging.StreamHandler(sys.stdout)
+logger.setLevel(logging.INFO)
+logger.addHandler(handler)
+
+proxy_url = os.environ.get("ALL_PROXY")
+if proxy_url is not None:
+    # Just try to check if proxy is http or https
+    # This does not validate the full url format
+    scheme = proxy_url.split(":")[0]
+
+    if scheme == "https":
+        logger.info("Creating certificate bundle with proxy root CA, and installing 'awsiotsdk', 'cbor' and 'psutil'")
+        try:
+            import certifi
+
+        except ImportError:
+            try:
+                from pip._vendor import certifi
+            except Exception:
+                logger.exception(
+                    "Error creating certificate bundle with proxy root CA. Python certifi module is not available on the device")
+                sys.exit(1)
+        try:
+            with open(certifi.where(), 'r') as certify_root_ca, open(os.environ.get("GG_ROOT_CA_PATH"), 'r') as gg_root_ca, open('./ca-bundle.crt', 'w') as custom_cert_bundle:
+                custom_cert_bundle.write(certify_root_ca.read())
+                custom_cert_bundle.write(gg_root_ca.read())
+        except Exception:
+            logger.exception("Error creating certificate bundle with proxy root CA")
+            sys.exit(1)
+        try:
+            subprocess.check_call(
+                [sys.executable, '-m', 'pip', 'install', '--cert', './ca-bundle.crt', 'awsiotsdk', 'cbor', 'psutil', '--user'])
+            sys.exit(0)
+        except Exception:
+            logger.exception(
+                "Error installing dependencies. Please set 'UseInstaller' to 'False' and pre-install 'awsiotsdk', 'cbor' and 'psutil'")
+            sys.exit(1)
+
+logger.info("Installing 'awsiotsdk', 'cbor' and 'psutil'")
+try:
+    subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'awsiotsdk', 'cbor', 'psutil', '--user'])
+except Exception:
+    logger.exception(
+        "Error installing dependencies. Please set 'UseInstaller' to 'False' and pre-install 'awsiotsdk', 'cbor' and 'psutil'")
+    sys.exit(1)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-git+git://github.com/aws-samples/aws-iot-device-defender-agent-sdk-python.git@a3d27c51311e12625bd0b774e8b730ead3bc515d
+git+https://github.com/aws-samples/aws-iot-device-defender-agent-sdk-python.git@a3d27c51311e12625bd0b774e8b730ead3bc515d


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
The change will install dependencies ('awsiotsdk', 'cbor' and 'psutil') needed for DeviceDefender component using custom cert bundle when Greengrass is running behind https proxy. The custom cert bundle is created by adding the users proxy root CA to the cert bundle used by pip.

**Why is this change necessary:**
The change is necessary as currently dependencies are installed via component recipe. In case of https proxy, normal `pip install` will fail during ssl verification as we don't provide any proxy CA to the command.

**How was this change tested:**
The change was tested using a custom component in UAT running with both https proxy and no proxy setup.

**Any additional information or context required to review the change:**
Similar PR: https://github.com/aws-greengrass/aws-greengrass-cloudwatch-metrics/pull/9
**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [ ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
