### PR TITLE
fix: add retry with jitter when client initialization failed

### DIFF
--- a/greengrass_defender_agent/agent.py
+++ b/greengrass_defender_agent/agent.py
@@ -49,9 +49,9 @@ def set_configuration(configuration):
 
 def set_env_variables_config():
     env_config = {}
-    if environ.get(config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY):
+    if environ.get(config.PUBLISH_RETRY_CONFIG_KEY):
         try:
-            connect_publish_retry = int(environ.get(config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY))
+            connect_publish_retry = int(environ.get(config.PUBLISH_RETRY_CONFIG_KEY))
         except (ValueError, TypeError):
             config.logger.warning(
                 "Invalid retry time. Using default retry count: {}".format(
@@ -59,24 +59,24 @@ def set_env_variables_config():
                 )
             )
             connect_publish_retry = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
-        if connect_publish_retry < config.MIN_CONNECT_AND_PUBLISH_RETRY:
+        if connect_publish_retry < config.MIN_PUBLISH_RETRY:
             config.logger.warning(
                 "Using minimum retry count: {}".format(
-                    config.MIN_CONNECT_AND_PUBLISH_RETRY
+                    config.MIN_PUBLISH_RETRY
                 )
             )
-            env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = config.MIN_CONNECT_AND_PUBLISH_RETRY
-        elif connect_publish_retry > config.MAX_CONNECT_AND_PUBLISH_RETRY:
+            env_config[config.PUBLISH_RETRY_CONFIG_KEY] = config.MIN_PUBLISH_RETRY
+        elif connect_publish_retry > config.MAX_PUBLISH_RETRY:
             config.logger.warning(
                 "Using maximum retry count: {}".format(
-                    config.MAX_CONNECT_AND_PUBLISH_RETRY
+                    config.MAX_PUBLISH_RETRY
                 )
             )
-            env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = config.MAX_CONNECT_AND_PUBLISH_RETRY
+            env_config[config.PUBLISH_RETRY_CONFIG_KEY] = config.MAX_PUBLISH_RETRY
         else:
-            env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = connect_publish_retry
+            env_config[config.PUBLISH_RETRY_CONFIG_KEY] = connect_publish_retry
     else:
-        env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
+        env_config[config.PUBLISH_RETRY_CONFIG_KEY] = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
         config.logger.warning(
             "Using default retry count: {}".format(
                 config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
@@ -168,7 +168,6 @@ def main():
     # Connect to the GG Nucleus
     need_retry = True
     retry_time = config.INITIAL_RETRY_INTERVAL_SECONDS
-    env_config = set_env_variables_config()
     connect_retry = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
 
     while (need_retry and connect_retry > 0):
@@ -197,7 +196,8 @@ def main():
     metrics_collector = collector.Collector(short_metrics_names=False)
 
     # Start collecting and publishing metrics
-    publish_retry = env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY]
+    env_config = set_env_variables_config()
+    publish_retry = env_config[config.PUBLISH_RETRY_CONFIG_KEY]
     need_retry = True
     retry_time = config.INITIAL_RETRY_INTERVAL_SECONDS
 

--- a/greengrass_defender_agent/agent.py
+++ b/greengrass_defender_agent/agent.py
@@ -171,7 +171,6 @@ def main():
     connect_retry = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
 
     while (need_retry and connect_retry > 0):
-        connect_retry -= 1
         try:
             ipc_client.connect()
             need_retry = False
@@ -184,6 +183,7 @@ def main():
 
             if connect_retry < 1:
                 exit(1)
+        connect_retry -= 1
 
     # Get initial configuration from the recipe
     configuration = ipc_client.get_configuration()
@@ -201,8 +201,7 @@ def main():
     need_retry = True
     retry_time = config.INITIAL_RETRY_INTERVAL_SECONDS
 
-    while (need_retry and publish_retry > 0):
-        publish_retry -= 1
+    while (need_retry and publish_retry >= 0):
         try:
             set_configuration_and_publish(ipc_client, configuration, metrics_collector)
             need_retry = False
@@ -212,6 +211,7 @@ def main():
                 retry_time = retry_time * 2 + randint(0, config.MAX_JITTER_TIME_INTERVAL_SECONDS)
             else:
                 retry_time = config.MAX_RETRY_INTERVAL_SECONDS
+        publish_retry -= 1
 
     # Subscribe to the subsequent configuration changes
     ipc_client.subscribe_to_config_updates()

--- a/greengrass_defender_agent/agent.py
+++ b/greengrass_defender_agent/agent.py
@@ -2,7 +2,9 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from threading import Timer, Thread
-
+from random import randint
+from time import sleep
+from os import environ
 from AWSIoTDeviceDefenderAgentSDK import collector
 from greengrass_defender_agent import config
 from greengrass_defender_agent import ipc_utils
@@ -43,6 +45,45 @@ def set_configuration(configuration):
         )
 
     return new_config
+
+
+def set_env_variables_config():
+    env_config = {}
+    if environ.get(config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY):
+        try:
+            connect_publish_retry = int(environ.get(config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY))
+        except (ValueError, TypeError):
+            config.logger.warning(
+                "Invalid retry time. Using default retry count: {}".format(
+                    config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
+                )
+            )
+            connect_publish_retry = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
+        if connect_publish_retry < config.MIN_CONNECT_AND_PUBLISH_RETRY:
+            config.logger.warning(
+                "Using minimum retry count: {}".format(
+                    config.MIN_CONNECT_AND_PUBLISH_RETRY
+                )
+            )
+            env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = config.MIN_CONNECT_AND_PUBLISH_RETRY
+        elif connect_publish_retry > config.MAX_CONNECT_AND_PUBLISH_RETRY:
+            config.logger.warning(
+                "Using maximum retry count: {}".format(
+                    config.MAX_CONNECT_AND_PUBLISH_RETRY
+                )
+            )
+            env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = config.MAX_CONNECT_AND_PUBLISH_RETRY
+        else:
+            env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = connect_publish_retry
+    else:
+        env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY] = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
+        config.logger.warning(
+            "Using default retry count: {}".format(
+                config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
+            )
+        )
+
+    return env_config
 
 
 def set_configuration_and_publish(ipc_client, configuration, metrics_collector):
@@ -103,16 +144,47 @@ def publish_metrics(ipc_client, config_changed, metrics_collector, sample_interv
         raise e
 
 
+def handle_expcetion_and_sleep(retry_action, exception, retry_time_sec, retry_count):
+    """
+    Handle exception and sleep for retry
+
+    :param retry_action: the name of retry action to print in the log
+    :param exception: the exception thrown from orginal action
+    :param retry_time_sec: number of seconds to sleep before the next retry
+    """
+    config.logger.exception(
+                "Exception occurred during the {} : {}".format(retry_action, exception)
+                )
+    config.logger.info(
+                "Will retry {} in {} seconds, retry count remaining: {}".format(retry_action, retry_time_sec, retry_count)
+            )
+    sleep(retry_time_sec)
+
+
 def main():
     # Get the ipc client
     ipc_client = ipc_utils.IPCUtils()
-    try:
-        ipc_client.connect()
-    except Exception as e:
-        config.logger.error(
-            "Exception occurred during the creation of an IPC client: {}".format(e)
-        )
-        exit(1)
+
+    # Connect to the GG Nucleus
+    need_retry = True
+    retry_time = config.INITIAL_RETRY_INTERVAL_SECONDS
+    env_config = set_env_variables_config()
+    connect_retry = config.DEFAULT_CONNECT_AND_PUBLISH_RETRY
+
+    while (need_retry and connect_retry > 0):
+        connect_retry -= 1
+        try:
+            ipc_client.connect()
+            need_retry = False
+        except Exception as e:
+            handle_expcetion_and_sleep("IPC client initialization", e, retry_time, connect_retry)
+            if retry_time < config.MAX_RETRY_INTERVAL_SECONDS:
+                retry_time = retry_time * 2 + randint(0, config.MAX_JITTER_TIME_INTERVAL_SECONDS)
+            else:
+                retry_time = config.MAX_RETRY_INTERVAL_SECONDS
+
+            if connect_retry < 1:
+                exit(1)
 
     # Get initial configuration from the recipe
     configuration = ipc_client.get_configuration()
@@ -125,7 +197,21 @@ def main():
     metrics_collector = collector.Collector(short_metrics_names=False)
 
     # Start collecting and publishing metrics
-    set_configuration_and_publish(ipc_client, configuration, metrics_collector)
+    publish_retry = env_config[config.CONNECT_AND_PUBLISH_RETRY_CONFIG_KEY]
+    need_retry = True
+    retry_time = config.INITIAL_RETRY_INTERVAL_SECONDS
+
+    while (need_retry and publish_retry > 0):
+        publish_retry -= 1
+        try:
+            set_configuration_and_publish(ipc_client, configuration, metrics_collector)
+            need_retry = False
+        except Exception as e:
+            handle_expcetion_and_sleep("metrics publish", e, retry_time, publish_retry)
+            if retry_time < config.MAX_RETRY_INTERVAL_SECONDS:
+                retry_time = retry_time * 2 + randint(0, config.MAX_JITTER_TIME_INTERVAL_SECONDS)
+            else:
+                retry_time = config.MAX_RETRY_INTERVAL_SECONDS
 
     # Subscribe to the subsequent configuration changes
     ipc_client.subscribe_to_config_updates()

--- a/greengrass_defender_agent/config.py
+++ b/greengrass_defender_agent/config.py
@@ -10,13 +10,21 @@ from awsiot.greengrasscoreipc.model import QOS
 
 # Set all the constants
 QOS_TYPE = QOS.AT_MOST_ONCE
+IPC_CONNECT_TIMEOUT = 120
 TIMEOUT = 10
 MIN_INTERVAL_SECONDS = 300  # minimum sample interval at which metrics messages can be published
 SCHEDULED_THREAD = None
 SAMPLE_INTERVAL_CONFIG_KEY = "SampleIntervalSeconds"
+PUBLISH_RETRY_CONFIG_KEY = "GG_DD_PUB_RETRY_COUNT"
+MIN_PUBLISH_RETRY = 0
+DEFAULT_CONNECT_AND_PUBLISH_RETRY = 5
+MAX_PUBLISH_RETRY = 72 # About 12 hours of max retry can be configured from customer side
 SAMPLE_INTERVAL_NEW_CONFIG_KEY = "sample_interval_secs"
 THING_NAME = os.environ.get("AWS_IOT_THING_NAME")
 TOPIC = "$aws/things/{thing_name}/defender/metrics/json".format(thing_name=THING_NAME)
+INITIAL_RETRY_INTERVAL_SECONDS = 5
+MAX_RETRY_INTERVAL_SECONDS = 600  # 10 minutes
+MAX_JITTER_TIME_INTERVAL_SECONDS = 30
 
 # Set a condition variable
 condition = Condition()

--- a/greengrass_defender_agent/ipc_utils.py
+++ b/greengrass_defender_agent/ipc_utils.py
@@ -45,7 +45,7 @@ class IPCUtils:
         )
         self.lifecycle_handler = LifecycleHandler()
         connect_future = connection.connect(self.lifecycle_handler)
-        connect_future.result(config.TIMEOUT)
+        connect_future.result(config.IPC_CONNECT_TIMEOUT)
         self.ipc_client = client.GreengrassCoreIPCClient(connection)
         config.logger.info("Created IPC client...")
 


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
This change was aim to address an issue reported from customer side. Customer discovered that the Greengrass Device Defender component stopped reporting metrics after internet interruption. Log diving revealed that the program exits by it self due to unhandled exception thrown in the logic. After troubleshooting and testing, following changes have been made:

* Fixed the exception logging when failed to connect from Device Defender component to Greengrass Nucleus. Customer should be able to see log trace if error ever thrown again from this part of the logic.
* Increased timeout threshold waiting for the `future` returned from `ipc_client.connect()` asynchronous call. 
* Added bounded inline retry when connecting from Device Defender component to Greengrass Nucleus. Retry time capped at 5 times to prevent resources leak.
* Added another configurable inline retry when publishing metrics to IoT Cloud. This retry has a back off strategy capped at 10 minutes of interval, with its default retry times count set to 5. Allowed retry times count is between 0 and 72. Customer can configure this publish retry count in the component recipe by setting the system environment argument `GG_DD_PUB_RETRY_COUNT`. Here is an example of how to set this argument in the recipe:

```
...

"Manifests": [
    {
      "Platform": {
        "os": "/darwin|linux/",
        "architecture": "*"
      },
      "Lifecycle": {
        "setEnv": {
          "GG_DD_PUB_RETRY_COUNT": "15"
      }
]

...
```

**How was this change tested:**
Manual testing with GG Nucleus and GG Device Defender component running on EC2
Steps:
1. Deploy GG Nucleus and GG Device Defender component to the device. 
2. Make sure GG Nucleus and GG Device Defender component running as normal.
3. Cut off internet by removing all outbound rules in the EC2 security group.
4. On the device emulating EC2, run command `sudo systemctl restart greengrass.service` to restart GG Nucleus.
5. Observe GG Device Defender component successfully connected to GG Nucleus upon program restart.
6. Verify device failed publish metrics to IoT Cloud due to connectivity loss.
7. Verify inline publish retry was performed and remaining retry count is as expected.
8. Resume internet connection on the device by adding "allow all traffic" rule to EC2 security group outbound rules.
9. Observe GG Device Defender component successfully published metrics to IoT Cloud.
**Any additional information or context required to review the change:**

**Checklist:**
 - [ N/A ] Updated the README if applicable
 - [ N/A ] Updated or added new unit tests
 - [ N/A ] Updated or added new integration tests
 - [ N/A ] Updated or added new end-to-end tests
 - [ N/A ] If your code makes a remote network call, it was tested with a proxy
 - [ Y ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
