### PR TITLE
fix: move retry into agent.publish_metrics function

### DIFF
--- a/greengrass_defender_agent/ipc_utils.py
+++ b/greengrass_defender_agent/ipc_utils.py
@@ -68,7 +68,7 @@ class IPCUtils:
             future.result(config.TIMEOUT)
             config.logger.info("Published to the IoT core...")
         except Exception as e:
-            config.logger.error("Exception occurred during publish to {}: {}".format(topic, e))
+            config.logger.exception("Exception occurred during publish to {}: {}".format(topic, e))
             raise e
 
     def subscribe_to_iot_core(self, topic):
@@ -86,7 +86,7 @@ class IPCUtils:
             future.result(config.TIMEOUT)
             config.logger.info("Subscribed to topic {}".format(topic))
         except Exception as e:
-            config.logger.error("Exception occurred during subscribe: {}".format(e))
+            config.logger.exception("Exception occurred during subscribe: {}".format(e))
             raise e
 
     def get_configuration(self):
@@ -102,7 +102,7 @@ class IPCUtils:
             result = operation.get_response().result(config.TIMEOUT)
             return result.value
         except Exception as e:
-            config.logger.error(
+            config.logger.exception(
                 "Exception occurred during fetching the configuration: {}".format(e)
             )
             raise e
@@ -120,7 +120,7 @@ class IPCUtils:
             subscribe_operation.activate(subsreq).result(config.TIMEOUT)
             subscribe_operation.get_response().result(config.TIMEOUT)
         except Exception as e:
-            config.logger.error(
+            config.logger.exception(
                 "Exception occurred during subscribing to the configuration updates: {}".format(e)
             )
             raise e
@@ -139,7 +139,7 @@ class ConfigUpdateHandler(client.SubscribeToConfigurationUpdateStreamHandler):
             config.condition.notify()
 
     def on_stream_error(self, error: Exception) -> bool:
-        config.logger.error("Error in config update subscriber - {0}".format(error))
+        config.logger.exception("Error in config update subscriber - {0}".format(error))
         return False
 
     def on_stream_closed(self) -> None:
@@ -162,7 +162,7 @@ class SubscribeToIoTCoreHandler(client.SubscribeToIoTCoreStreamHandler):
         config.logger.debug("Received message from topic {}: {}".format(self.topic, received_message))
 
     def on_stream_error(self, error: Exception) -> bool:
-        config.logger.error("Error in Iot Core subscriber - {0}".format(error))
+        config.logger.exception("Error in Iot Core subscriber - {0}".format(error))
         return False
 
     def on_stream_closed(self) -> None:


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Move retry into ipc_client.publish_to_iot_core. In a previous version @youtuyy found out after testing that publish retry would exit without functioning. Moving the logic inside `agent.publish_metrics` function.


**How was this change tested:**
1. Observe publish to IoT success in the DD component log.
2. Use command 
```
sudo iptables -A INPUT -p tcp -s localhost --dport 8883 -j ACCEPT && sudo iptables -A INPUT -p tcp --dport 8883 -j DROP && sudo iptables -A OUTPUT -p tcp -d localhost --dport 8883 -j ACCEPT && sudo iptables -A OUTPUT -p tcp --dport 8883 -j DROP
 
sudo iptables -A INPUT -p tcp -s localhost --dport 443 -j ACCEPT && sudo iptables -A INPUT -p tcp --dport 443 -j DROP && sudo iptables -A OUTPUT -p tcp -d localhost --dport 443 -j ACCEPT && sudo iptables -A OUTPUT -p tcp --dport 443 -j DROP
```

To kill the MQTT connection.

3. Observe publish failed but retry initiated. In my case I see following changes

```
......
2022-08-23T17:19:25.639Z [INFO] (Copier) aws.greengrass.DeviceDefenderTest8: stdout. raise shape. {scriptName=services.aws.greengrass.DeviceDefenderTest8.lifecycle.run.script, serviceName=aws.greengrass.DeviceDefenderTest8, currentState=RUNNING}
2022-08-23T17:19:25.639Z [INFO] (Copier) aws.greengrass.DeviceDefenderTest8: stdout. awsiot.greengrasscoreipc.model.ServiceError. {scriptName=services.aws.greengrass.DeviceDefenderTest8.lifecycle.run.script, serviceName=aws.greengrass.DeviceDefenderTest8, currentState=RUNNING}
2022-08-23T17:19:25.639Z [INFO] (Copier) aws.greengrass.DeviceDefenderTest8: stdout. Will retry metrics publish in 33 seconds, retry count remaining: 14. {scriptName=services.aws.greengrass.DeviceDefenderTest8.lifecycle.run.script, serviceName=aws.greengrass.DeviceDefenderTest8, currentState=RUNNING}
```
4. Resume MQTT connection using following command

```
sudo iptables --delete INPUT -p tcp -s localhost --dport 8883 -j ACCEPT && sudo iptables --delete INPUT -p tcp --dport 8883 -j DROP && sudo iptables --delete OUTPUT -p tcp -d localhost --dport 8883 -j ACCEPT && sudo iptables --delete OUTPUT -p tcp --dport 8883 -j DROP
 
sudo iptables --delete INPUT -p tcp -s localhost --dport 443 -j ACCEPT && sudo iptables --delete INPUT -p tcp --dport 443 -j DROP && sudo iptables --delete OUTPUT -p tcp -d localhost --dport 443 -j ACCEPT && sudo iptables --delete OUTPUT -p tcp --dport 443 -j DROP
```

5. Observe from log the publish succeeded
```
2022-08-23T17:21:13.694Z [INFO] (Copier) aws.greengrass.DeviceDefenderTest8: stdout. Will retry metrics publish in 150 seconds, retry count remaining: 12. {scriptName=services.aws.greengrass.DeviceDefenderTest8.lifecycle.run.script, serviceName=aws.greengrass.DeviceDefenderTest8, currentState=RUNNING}
2022-08-23T17:23:43.735Z [INFO] (Copier) aws.greengrass.DeviceDefenderTest8: stdout. Published to the IoT core.... {scriptName=services.aws.greengrass.DeviceDefenderTest8.lifecycle.run.script, serviceName=aws.greengrass.DeviceDefenderTest8, currentState=RUNNING}
```


**Any additional information or context required to review the change:**

**Checklist:**
 - [ N/A ] Updated the README if applicable
 - [ N/A ] Updated or added new unit tests
 - [ N/A ] Updated or added new integration tests
 - [ N/A ] Updated or added new end-to-end tests
 - [ N/A ] If your code makes a remote network call, it was tested with a proxy
 - [ Y ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
