### PR TITLE
Fix link to device defender SDK in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This is an AWS GreengrassV2 Component that reads system metrics on the device an
 ## FAQ
 
 ## Dependencies
-[AWS IoT Device Defender Agent SDK (Python)](https://github.com/aws-samples/aws-iot-device-defender-agent-sdk-python>)
+[AWS IoT Device Defender Agent SDK (Python)](https://github.com/aws-samples/aws-iot-device-defender-agent-sdk-python)
 
 
 ## Sample Configuration


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
Fixed link to Device Defender SDK in README

**Why is this change necessary:**
Fixes README link

**How was this change tested:**
Manually clicked on the new link to see if the redirect worked.

**Any additional information or context required to review the change:**

**Checklist:**
 - [v ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [v ] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
