### PR TITLE
gracefully shutdown metrics emitting when interpreter has exited

### DIFF
--- a/greengrass_defender_agent/config.py
+++ b/greengrass_defender_agent/config.py
@@ -14,6 +14,7 @@ IPC_CONNECT_TIMEOUT = 120
 TIMEOUT = 10
 MIN_INTERVAL_SECONDS = 300  # minimum sample interval at which metrics messages can be published
 SCHEDULED_THREAD = None
+IS_SHUTTING_DOWN = False
 SAMPLE_INTERVAL_CONFIG_KEY = "SampleIntervalSeconds"
 PUBLISH_RETRY_CONFIG_KEY = "GG_DD_PUB_RETRY_COUNT"
 MIN_PUBLISH_RETRY = 0


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* adding graceful shutdown log to component

**Why is this change necessary:**
* Prevent `aws.greengrass.DeviceDefender: stdout. RuntimeError: can't create new thread at interpreter shutdown` exception from occurring while the component is shutting down

**How was this change tested:**
* copied python changes to a local GreenGrass install
* ran `./bin/greengrass-cli component stop -n aws.greengrass.DeviceDefender` and `./bin/greengrass-cli component restart -n aws.greengrass.DeviceDefender` multiple times
* verified there was no error for `can't create new thread at interpreter shutdown`

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
