### PR TITLE
join configuration change thread from main thread to prevent 'Runtime…

### DIFF
--- a/greengrass_defender_agent/agent.py
+++ b/greengrass_defender_agent/agent.py
@@ -218,7 +218,10 @@ def main():
  
     # Subscribe to the subsequent configuration changes
     ipc_client.subscribe_to_config_updates()
-    Thread(
+    configChangeThread = Thread(
         target=wait_for_config_changes,
         args=(ipc_client, metrics_collector),
-    ).start()
+    )
+    configChangeThread.start()
+    configChangeThread.join()
+    


### PR DESCRIPTION
**Issue #, if available:**

**Description of changes:**
* Minor changes to Thread handling

**Why is this change necessary:**
* Prevent `aws.greengrass.DeviceDefender: stdout. RuntimeError: can't create new thread at interpreter shutdown`

**How was this change tested:**
* reproduced issue by waiting for the existing python script to emit 2 Device Defender metric reports with Python 3.12
* copied new changes to a local GreenGrass install
* ran `./bin/greengrass-cli component stop -n aws.greengrass.DeviceDefender` and `./bin/greengrass-cli component restart -n aws.greengrass.DeviceDefender` multiple times
* verified there was no error for `can't create new thread at interpreter shutdown` after 2 Device Metric reports were sent to Device Defender

**Any additional information or context required to review the change:**

**Checklist:**
 - [ ] Updated the README if applicable
 - [ ] Updated or added new unit tests
 - [ ] Updated or added new integration tests
 - [ ] Updated or added new end-to-end tests
 - [ ] If your code makes a remote network call, it was tested with a proxy
 - [x] You confirm that the change is backwards compatible

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.